### PR TITLE
Fix apt-get command not found error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM bellsoft/liberica-openjdk-rocky:17.0.16-cds
 WORKDIR /app
 
 # 安装必要工具
-RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
+RUN yum update -y && yum install -y curl && yum clean all
 
 # 复制应用JAR文件
 COPY target/*.jar app.jar


### PR DESCRIPTION
Replace `apt-get` with `yum` in the Dockerfile to resolve `command not found` errors on the Rocky Linux base image.

---
[Slack Thread](https://sino-rlm9033.slack.com/archives/C09DNJY9ND8/p1757058158297069?thread_ts=1757058158.297069&cid=C09DNJY9ND8)

<a href="https://cursor.com/background-agent?bcId=bc-eeb954f6-0a20-4eeb-b52f-597cc22fedc8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-eeb954f6-0a20-4eeb-b52f-597cc22fedc8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

