### PR TITLE
Fix apt-get command not found error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,18 +2,16 @@ FROM bellsoft/liberica-openjdk-rocky:17.0.16-cds
 
 WORKDIR /app
 
-# 安装必要工具
-RUN yum update -y && yum install -y curl && yum clean all
-
 # 复制应用JAR文件
 COPY target/*.jar app.jar
 
 # 创建日志目录
 RUN mkdir -p /app/logs
 
-# 健康检查
+# 健康检查 - 使用wget (通常在最小化镜像中可用) 或简单的端口检查
 HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
-  CMD curl -f http://localhost:8080/actuator/health || exit 1
+  CMD wget --no-verbose --tries=1 --spider http://localhost:8080/actuator/health || \
+      (echo > /dev/tcp/localhost/8080) 2>/dev/null || exit 1
 
 # 暴露端口
 EXPOSE 8080


### PR DESCRIPTION
Refactor Dockerfile to remove package manager dependencies and use a minimal health check for `bellsoft/liberica-openjdk-rocky` base image.

The `bellsoft/liberica-openjdk-rocky` base image is a highly minimal distribution that lacks traditional package managers like `apt-get` or `yum`/`dnf`. This PR removes the attempt to install `curl` and instead implements a health check using `wget` (if available) or a direct TCP connection, aligning with the minimal nature of the base image.

---
[Slack Thread](https://sino-rlm9033.slack.com/archives/C09DNJY9ND8/p1757058158297069?thread_ts=1757058158.297069&cid=C09DNJY9ND8)

<a href="https://cursor.com/background-agent?bcId=bc-eeb954f6-0a20-4eeb-b52f-597cc22fedc8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-eeb954f6-0a20-4eeb-b52f-597cc22fedc8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

